### PR TITLE
fix(ci): quote run commands containing '#' so workflow YAML parses

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm deprecate unity-rich-text-converter@0.1.9 "Broken: published without a dist build (see issue #15). Please upgrade to a fixed version."
+      - run: 'npm deprecate unity-rich-text-converter@0.1.9 "Broken: published without a dist build (see issue #15). Please upgrade to a fixed version."'
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
       # Derive the published version from the release tag (e.g. v0.1.10 -> 0.1.10)
       # so package.json can stay at 0.1.9 in the repo while we never republish it.
       - name: Set package version from release tag
-        run: npm pkg set version="${GITHUB_REF_NAME#v}"
+        run: 'npm pkg set version="${GITHUB_REF_NAME#v}"'
       - run: npm run build
       - run: npm publish
         env:


### PR DESCRIPTION
## Summary

Fixes the `Invalid workflow file` CI failure introduced when `deprecate.yml` (and the version-from-tag step in `npm-publish.yml`) were added.

### Root cause
The `run:` command in `deprecate.yml` contained a `#` (in `see issue #15`) inside an **unquoted** YAML scalar. YAML treats `#` as a comment there, which truncated the command and left an unclosed double-quote -> parser error on line 19 (`Invalid workflow file / mapping values are not allowed here`).

`npm-publish.yml` had the **same latent bug** in the version-from-tag step (`run: npm pkg set version="${GITHUB_REF_NAME#v}"`): the `#v` would be parsed as a comment and break the first release run.

### Fix
Wrap both `run:` commands in single quotes so `#` is treated as a literal character:
- `deprecate.yml`: `'npm deprecate ... "see issue #15" ...'`
- `npm-publish.yml`: `'npm pkg set version="${GITHUB_REF_NAME#v}"'`

Both files now parse as valid YAML (verified with a YAML parser locally).

### Related
These workflows were added as part of the #15 fix (CI-native publish + one-shot deprecate for the broken 0.1.9). This PR only fixes their YAML so they actually load/run.
