### PR TITLE
ci: fail publish if dist/ is missing (guard against #15 repeat)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Set package version from release tag
         run: 'npm pkg set version="${GITHUB_REF_NAME#v}"'
       - run: npm run build
+      - name: Guard - ensure dist build output exists
+        run: 'test -f dist/index.js || (echo "ERROR: dist/index.js missing after build; aborting publish (see issue #15)" && exit 1)'
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Add a publish guard: after `npm run build`, fail the workflow if `dist/index.js` is absent. This makes issue #15 self-defeating - a broken or missing build can no longer slip through to a published package. package.json is untouched per project convention; no functional change to the published artifact.